### PR TITLE
Allow override of content type

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -15,6 +15,7 @@
       this.name = name;
       this.authorization = null;
       this.proxy = null;
+      this.contentType = 'application/json';
     }
 
     Database.prototype.getUrl = function() {
@@ -24,6 +25,10 @@
         url += "/databases/" + this.name;
       }
       return url;
+    };
+
+    Database.prototype.setContentType = function(contentType) {
+      return this.contentType = contentType;
     };
 
     Database.prototype.getDocsUrl = function() {
@@ -519,7 +524,8 @@
         bodyOrReadableStream.pipe(op.call(request, req, cb));
         return;
       }
-      req[typeof bodyOrReadableStream === 'object' ? 'json' : 'body'] = bodyOrReadableStream;
+      headers['content-type'] = this.contentType;
+      req['body'] = typeof bodyOrReadableStream === 'object' ? JSON.stringify(bodyOrReadableStream) : bodyOrReadableStream;
       op.call(request, req, cb);
       return null;
     };

--- a/src/database.coffee
+++ b/src/database.coffee
@@ -9,12 +9,15 @@ class Database
   constructor: (@datastore, @name) ->
     @authorization = null # Nothing by default
     @proxy = null         # Nothing by default
+    @contentType = 'application/json'
 
   getUrl: ->
     url = @datastore.url
     url += "/databases/#{@name}" unless @name is 'Default'
     url
 
+  setContentType: (contentType)->
+    @contentType = contentType;
 
   getDocsUrl: ->
     "#{@getUrl()}/docs"
@@ -397,7 +400,8 @@ class Database
       bodyOrReadableStream.pipe(op.call(request, req, cb))
       return
 
-    req[if typeof bodyOrReadableStream is 'object' then 'json' else 'body'] = bodyOrReadableStream
+    headers['content-type'] = @contentType
+    req['body'] = if typeof bodyOrReadableStream is 'object' then JSON.stringify(bodyOrReadableStream) else bodyOrReadableStream
 
     op.call(request, req, cb)
 


### PR DESCRIPTION
Sometimes you need to save documents containing non english chars.
This patch allows you to set a content type to save the document with.
