### PR TITLE
Fix typo

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -54,7 +54,7 @@
     };
 
     Database.prototype.getQueriesUrl = function() {
-      return this.api.getQueryiesUrl();
+      return this.api.getQueriesUrl();
     };
 
     Database.prototype.getBulkDocsUrl = function() {


### PR DESCRIPTION
I got the following error when calling getDocuments:

	node_modules\ravendb\lib\database.js:57
	      return this.api.getQueryiesUrl();
			      ^
	TypeError: Object #<Api> has no method 'getQueryiesUrl'
	    at Database.getQueriesUrl (d:\reporting\node_modules\ravendb\lib\database.js
	:57:23)
