### PR TITLE
Update database.js

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -116,7 +116,7 @@
       op.call(this, url, doc, doc.getMetadata(), function(error, response) {
         if (!error && response.statusCode === 201) {
           doc.setMetadataValues(JSON.parse(response.body));
-          doc.id = doc.getMetadataValue('key');
+          doc.id = doc.getMetadataValue('__document_id');
           if (cb != null) {
             return cb(null, doc);
           }
@@ -140,7 +140,7 @@
         if (!error && response.statusCode === 200) {
           doc = Document.fromObject(JSON.parse(response.body));
           doc.setMetadataValues(response.headers);
-          doc.id = doc.getMetadataValue('key');
+          doc.id = doc.getMetadataValue('__document_id');
           return cb(null, doc);
         } else {
           return cb(error);


### PR DESCRIPTION
Fix the document ID coming back from the metadata (Not 'key' anymore but '__document_id')

In my test with ravendb 2.5 and 3.0 when I have a normal project the document ID is always coming back with the metadata __document_id (header). 
